### PR TITLE
The documentation does not mention that the NodeInterface type needs to be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ If you're using the resolver from MVC (`IServiceProvider`), that might look like
 ```csharp
 services.AddTransient(typeof(ConnectionType<>));
 services.AddTransient(typeof(EdgeType<>));
-services.AddTransient<PageInfoType>
-services.AddTransient<NodeInterface>
+services.AddTransient<PageInfoType>();
+services.AddTransient<NodeInterface>();
 ```
 
 ### GraphTypes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ensure your resolver for GraphQL can resolve:
 * `ConnectionType<>`
 * `EdgeType<>`
 * `PageInfoType`
+* `NodeInterface`
 
 If you're using the resolver from MVC (`IServiceProvider`), that might look like this:
 
@@ -24,6 +25,7 @@ If you're using the resolver from MVC (`IServiceProvider`), that might look like
 services.AddTransient(typeof(ConnectionType<>));
 services.AddTransient(typeof(EdgeType<>));
 services.AddTransient<PageInfoType>
+services.AddTransient<NodeInterface>
 ```
 
 ### GraphTypes

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Ensure your resolver for GraphQL can resolve:
 
 * `ConnectionType<>`
 * `EdgeType<>`
-* `PageInfoType`
 * `NodeInterface`
+* `PageInfoType`
 
 If you're using the resolver from MVC (`IServiceProvider`), that might look like this:
 
 ```csharp
 services.AddTransient(typeof(ConnectionType<>));
 services.AddTransient(typeof(EdgeType<>));
-services.AddTransient<PageInfoType>();
 services.AddTransient<NodeInterface>();
+services.AddTransient<PageInfoType>();
 ```
 
 ### GraphTypes


### PR DESCRIPTION
The documentation does not mention that the `NodeInterface` type needs to be resolved in order for `node` queries to work (see #17).