### PR TITLE
feat: update references to GraphQL to release version 2.0.0

### DIFF
--- a/src/GraphQL.Relay.StarWars/GraphQL.Relay.StarWars.csproj
+++ b/src/GraphQL.Relay.StarWars/GraphQL.Relay.StarWars.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DataLoader" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-938" />
+    <PackageReference Include="GraphQL" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Scrutor" Version="2.1.2" />
   </ItemGroup>

--- a/src/GraphQL.Relay.Todo/GraphQL.Relay.Todo.csproj
+++ b/src/GraphQL.Relay.Todo/GraphQL.Relay.Todo.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-938" />
+    <PackageReference Include="GraphQL" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GraphQL.Relay\GraphQL.Relay.csproj" />

--- a/src/GraphQL.Relay/GraphQL.Relay.csproj
+++ b/src/GraphQL.Relay/GraphQL.Relay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>Jason Quense</Authors>
-    <VersionPrefix>0.6.0-pre2</VersionPrefix>
+    <VersionPrefix>0.6.0-pre3</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <AssemblyName>GraphQL.Relay</AssemblyName>
     <PackageId>GraphQL.Relay</PackageId>
@@ -13,7 +13,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-938" />
+    <PackageReference Include="GraphQL" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="HttpMultipartParser" Version="2.2.4" />
     <PackageReference Include="Panic.StringUtils" Version="1.0.1" />


### PR DESCRIPTION
GraphQL 2 has been released. This updates the references accordingly.