### PR TITLE
Fix SWAPI URL

### DIFF
--- a/src/GraphQL.Relay.StarWars/Api/Swapi.cs
+++ b/src/GraphQL.Relay.StarWars/Api/Swapi.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Relay.StarWars.Api
   {
     private readonly HttpClient _client;
 
-    private string _apiBase = "http://swapi.co/api";
+    private const string _apiBase = "http://swapi.dev/api";
     private ResponseCache _cache = new ResponseCache();
 
 

--- a/src/GraphQL.Relay.StarWars/Api/Swapi.cs
+++ b/src/GraphQL.Relay.StarWars/Api/Swapi.cs
@@ -80,7 +80,7 @@ namespace GraphQL.Relay.StarWars.Api
     public async Task<List<T>> GetConnection<T>(ConnectionArguments args)
         where T : Entity
     {
-      var nextUrl = new Uri($"{_apiBase}/{typeof(T).Name.ToLower()}");
+      var nextUrl = new Uri($"{_apiBase}/{typeof(T).Name.ToLower()}/");
       var entities = new List<T>();
       var canStopEarly =
           args.After != null ||


### PR DESCRIPTION
The Star Wars sample application is broken because [swapi.co](https://swapi.co/) is down, as in https://swapi.dev/about:

>## What happened to swapi.co?
>Unfortulately swapi.co is not maintained anymore, and the service is currently down. This is an branch of SWAPI that will be supported going forward.

This changes `Swapi._apiBase` to the new address. Additionally, the new api requires a trailing slash for the base endpoints or else it returns `301 Moved Permanently`; the app breaks because the client does not follow that.