### PR TITLE
Get object

### DIFF
--- a/src/GraphQL.Relay/Types/MutationInputs.cs
+++ b/src/GraphQL.Relay/Types/MutationInputs.cs
@@ -21,12 +21,7 @@ namespace GraphQL.Relay.Types
         {
             if (!TryGetValue(key, out object value))
                 return defaultValue;
-            if (value is Dictionary<string, object> dictionary)
-            {
-                return dictionary.ToObject<T>();
-            }
-
-            return (T)value;
+            return value is Dictionary<string, object> dictionary ? dictionary.ToObject<T>() : (T)value;
         }
     }
 }


### PR DESCRIPTION
Hi guys,

I had a bottleneck trying to achieve the following:

Mutation declaration:
`           this.Mutation<RegisterAgentInputGraphType, RegisterAgentMutationPayloadGraphType>("register");`

Input Graph Type:
```

public class RegisterAgentInputGraphType : MutationInputGraphType
    {
        public RegisterAgentInputGraphType()
        {
            this.Field<NonNullGraphType<GuidGraphType>>(Constants.Fields.API_KEY);
            this.Field<NonNullGraphType<AgentDetailInputGraphType>>(Constants.Fields.AGENT_DETAILS);
        }
    }

public class AgentDetailInputGraphType : InputObjectGraphType
    {
        public AgentDetailInputGraphType()
        {
            this.Field<NonNullGraphType<StringGraphType>>(Constants.Fields.IP_ADDRESS);
            this.Field<NonNullGraphType<StringGraphType>>(Constants.Fields.NAME);
            this.Field<NonNullGraphType<StringGraphType>>(Constants.Fields.OS);
        }
    }
```

DTO

```
 public class AgentDetailDto
    {
        public string IpAddress { get; init; }
        public string Os { get; init; }
        public string Name { get; init; }
    }
```

Mutation

```
 public class RegisterAgentMutationPayloadGraphType : MutationPayloadGraphType
    {
        public override object MutateAndGetPayload(MutationInputs inputs, IResolveFieldContext<object> context)
        {
            var apiKey = inputs.GetGuid(Constants.Fields.API_KEY);
            var agentDetails = inputs.Get<AgentDetailDto>(Constants.Fields.AGENT_DETAILS);

            throw new NotImplementedException();
        }
    }
```

The query

```
mutation{
  agents{
     register(input:{
      apiKey:"a8aba2e5b2fc4c8486072491a9bf3d11"
       agentDetails:{
        ipAddress:"a"
        name:"a"
        os:"o"
      }
    }){
      clientMutationId
    }
  }
}

```


I've had the following error message: 
**System.InvalidCastException : 'Unable to cast object of type 'System.Collections.Generic.Dictionary`2[System.String,System.Object]' to type 'Owl.DAL.DTO.AgentDetailDto'.'**

I've just created this pull request to convert the dictionary values into the object passed as param

Cheers,
